### PR TITLE
Fix for sorting in Safari

### DIFF
--- a/src/client/js/components/main.js
+++ b/src/client/js/components/main.js
@@ -14,7 +14,7 @@ const formatGameTime = (game) => {
 const getNextGame = (now, games) => {
   return games
     .filter((game) => { return isAfter(game.date, now); })
-    .sort((game) => { return -getTime(game.date); })
+    .sort((a, b) => { return getTime(a.date)-getTime(b.date); })
     .shift();
 };
 


### PR DESCRIPTION
Array.sort comparison function takes 2 arguments, not one. Chrome and Safari exhibit different behaviours in this case with only 1 argument. This can see seen by entering
`[3,2,1].sort(function(a){return -a;})` in the console of Chrome and Safari. Chrome returns `[3,2,1]`, Safari returns `[1,2,3]`