### PR TITLE
Fix sorting issue that broke chrome and safari

### DIFF
--- a/src/client/js/components/hoc/inject-with-game.js
+++ b/src/client/js/components/hoc/inject-with-game.js
@@ -7,7 +7,7 @@ const UPDATE_INTERVAL = 1000;
 const getNextGame = (now, games) => {
   return games
     .filter((game) => { return isAfter(game.date, now); })
-    .sort((game) => { return -getTime(game.date); })
+    .sort((game1, game2) => { return getTime(game1.date) > getTime(game2.date); })
     .shift();
 };
 


### PR DESCRIPTION
Fixes #25. Apparently a single argument sort works different between firefox and chrome/safari. Explicitly defining the sort has sorted out the problem (see what I did there?).

@baer (for visibility)